### PR TITLE
feature/daily-reader-stats

### DIFF
--- a/app/assets/stylesheets/sidebar-data.scss
+++ b/app/assets/stylesheets/sidebar-data.scss
@@ -16,3 +16,11 @@
     border-radius: 3px;
   }
 }
+
+.daily-stats {
+  h3 {
+    color: $dark-green;
+  }
+  border-top: 1px solid $light-medium-gray;
+  padding: 0 16px 16px 16px;
+}

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,6 +1,7 @@
 $black: #0a0a0a;
 $white: #ffffff;
 $green: #66e2d5;
+$dark-green: #0c4442;
 $light-green: lighten($green, 30%);
 $dark-purple: #4e57ef;
 $purple: #cfd7ff;

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -56,6 +56,13 @@
             <%= pluralize @user.decorate.cached_followed_tags.size, "Tag" %> Followed
           </div>
         </div>
+        <div class="daily-stats">
+          <h3>Daily Stats</h3>
+          <p>3 Visits</p>
+          <p>35 Minutes on Pages</p>
+          <p>4 Articles Read</p>
+          <p>1456 Words Read</p>
+        </div>
       <% end %>
     </div>
   </div>


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure you've done the following:
     - Read the DEV Contributing Guide and the Code of Conduct
     - Provided tests for your changes
     - Used descriptive commit messages
     - Updated any relevant documentation and added any necessary screenshots
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
This PR adds a placeholder section where a user's daily stats (# visits, active time on pages, # articles read, and # words read) on their profile page. This closes #42 

## Related Tickets & Documents
N/A

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
N/A

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] docs.dev.to
- [ ] readme
- [x] no documentation needed

## [optional] Are there any post deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

![alt_text](gif_link)
